### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,25 @@ function patch<T extends R, U extends FullyPartial<T>>(target: T, patch: U): voi
     patchRecursive(target, patch);
 }
 
+const ILLEGAL_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+const isIllegalKey = (key: string): Boolean => ILLEGAL_KEYS.has(key)
+
+const isProtoPath = (path: string[] | string): Boolean => Array.isArray(path)
+  ? path.some(isIllegalKey)
+  : typeof path === "string"
+    ? isIllegalKey(path)
+    : false
+
+const disallowProtoPath = (path: string[] | string): void | never => {
+  if (isProtoPath(path)) {
+    throw new Error(`Unsafe path encountered: ${path.toString()}`)
+  }
+}
+
 function patchRecursive(target: any, patch: any): any {
     const keys = Object.keys(patch);
+    disallowProtoPath(keys);
     for (const key of keys) {
         if (is.primitive(target[key]) || is.array(target[key])) {
             target[key] = patch[key];

--- a/test/index.ts
+++ b/test/index.ts
@@ -175,4 +175,9 @@ describe('Tests:', () => {
         });
     });
 
+    test('patches must throw for unsafe objects', () => {
+      const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+      expect(() => patch({}, payload)).toThrow();
+    })
+
 });


### PR DESCRIPTION
### 📊 Metadata *

`json-merge-patch-in-place` is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-json-merge-patch-in-place

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var { patch } = require("json-merge-patch-in-place")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
patch(obj, payload);
console.log("After : " + {}.polluted);
```

2. Execute the following commands in terminal:

```
npm i json-merge-patch-in-place # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106926066-b5261980-6736-11eb-986d-5b20ea5a692f.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106926172-d4bd4200-6736-11eb-9be2-fe07145fed2b.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106926960-a9872280-6737-11eb-9cfc-01f1d8107b6f.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1831
